### PR TITLE
fix: Remove zScale

### DIFF
--- a/src/DxfScene.js
+++ b/src/DxfScene.js
@@ -1467,10 +1467,6 @@ class BlockContext {
         const rotation = -(entity.rotation || 0) * Math.PI / 180
         let x = entity.position.x
         const y = entity.position.y
-        if (entity.zScale < 0) {
-            yScale = -yScale
-            x = -x
-        }
         mInsert.scale(xScale, yScale)
         mInsert.rotate(rotation)
         mInsert.translate(x, y)


### PR DESCRIPTION
Since dxf-viewer is 2D,  zScale has no effect on the XY based screen.
Below is the problem:
In dwg file, the door is in the wall
![image](https://user-images.githubusercontent.com/22880091/142712559-6c16a83f-ea1d-487d-9bd7-9401145c486e.png)
And in dxf-viewer, the door's x and y become -x and -y:
![image](https://user-images.githubusercontent.com/22880091/142712608-8e4e7ee9-6e1e-4751-b6ed-b7d0c77ad7cf.png)

You can Reproduce this bug from the attached dxf.tex file.
Since github don't support .dxf file, I change the file extension to txt.
[dxf.txt](https://github.com/vagran/dxf-viewer/files/7573842/dxf.txt)


