### PR TITLE
Convert layer name unicode characters to ASCII

### DIFF
--- a/src/DxfScene.js
+++ b/src/DxfScene.js
@@ -1225,14 +1225,14 @@ export class DxfScene {
         return new Matrix3().scale(-1, 1)
     }
 
-    /**
+     /**
      * Parse special characters in text entities and convert them to corresponding unicode
      * characters.
      * https://knowledge.autodesk.com/support/autocad/learn-explore/caas/CloudHelp/cloudhelp/2019/ENU/AutoCAD-Core/files/GUID-518E1A9D-398C-4A8A-AC32-2D85590CDBE1-htm.html
      * @param {string} text Raw string.
      * @return {string} String with special characters replaced.
      */
-    _ParseSpecialChars(text) {
+      _ParseSpecialChars(text) {
         return text.replaceAll(SPECIAL_CHARS_RE, (match, p1, p2) => {
             if (p1 !== undefined) {
                 switch (p1) {
@@ -1354,6 +1354,7 @@ export class DxfScene {
         for (const layer of this.layers.values()) {
             scene.layers.push({
                 name: layer.name,
+                normalizedName: layer.normalizedName,
                 color: layer.color
             })
         }

--- a/src/DxfViewer.js
+++ b/src/DxfViewer.js
@@ -176,7 +176,7 @@ export class DxfViewer {
         this.hasMissingChars = scene.hasMissingChars
 
         for (const layer of scene.layers) {
-            this.layers.set(layer.name, new Layer(layer.name, layer.color))
+            this.layers.set(layer.name, new Layer(layer.name, layer.normalizedName, layer.color))
         }
 
         /* Load all blocks on the first pass. */
@@ -230,11 +230,11 @@ export class DxfViewer {
         this.renderer.render(this.scene, this.camera)
     }
 
-    /** @return {Iterable<{name:String, color:number}>} List of layer names. */
+    /** @return {Iterable<{name:String, normalizedName:String, color:number}>} List of layer names. */
     GetLayers() {
         const result = []
         for (const lyr of this.layers.values()) {
-            result.push({name: lyr.name, color: this._TransformColor(lyr.color)})
+            result.push({name: lyr.name, normalizedName: lyr.normalizedName, color: this._TransformColor(lyr.color)})
         }
         return result
     }
@@ -888,8 +888,9 @@ class Batch {
 }
 
 class Layer {
-    constructor(name, color) {
+    constructor(name, normalizedName, color) {
         this.name = name
+        this.normalizedName = normalizedName
         this.color = color
         this.objects = []
     }

--- a/src/parser/DxfParser.js
+++ b/src/parser/DxfParser.js
@@ -20,6 +20,8 @@ import Text from './entities/text';
 
 import log from 'loglevel';
 
+import * as helpers from './ParseHelpers';
+
 //log.setLevel('trace');
 //log.setLevel('debug');
 //log.setLevel('info');
@@ -585,9 +587,8 @@ DxfParser.prototype._parse = function(dxfString) {
 
             switch(curr.code) {
                 case 2: // layer name
-                    layer.name = curr.value.replace(/\\u\+([0-9A-F]{4})/ig, function (_, group1) {
-                        return String.fromCharCode(parseInt(group1, 16));
-                    });
+                    layer.name = curr.value;
+                    layer.normalizedName = helpers.parseUnicodeChars(curr.value);
                     layerName = curr.value;
                     curr = scanner.next();
                     break;

--- a/src/parser/DxfParser.js
+++ b/src/parser/DxfParser.js
@@ -585,7 +585,9 @@ DxfParser.prototype._parse = function(dxfString) {
 
             switch(curr.code) {
                 case 2: // layer name
-                    layer.name = curr.value;
+                    layer.name = curr.value.replace(/\\u\+([0-9A-F]{4})/ig, function (_, group1) {
+                        return String.fromCharCode(parseInt(group1, 16));
+                    });
                     layerName = curr.value;
                     curr = scanner.next();
                     break;

--- a/src/parser/ParseHelpers.js
+++ b/src/parser/ParseHelpers.js
@@ -127,3 +127,14 @@ export function checkCommonEntityProperties(entity, curr) {
     }
     return true;
 }
+
+/**
+* Convert unicode characters (\U+XXXX) to its equivalent in ASCII characters
+* @param {string} text Raw string.
+* @return {string} String with special characters replaced.
+*/
+export function parseUnicodeChars(text) {
+    return text.replace(/\\u\+([0-9A-F]{4})/ig, function (_, group1) {
+        return String.fromCharCode(parseInt(group1, 16));
+    });
+}


### PR DESCRIPTION
Layers that had special characters in the name were converted to Unicode characters (\U+XXXX).

![image](https://user-images.githubusercontent.com/45567815/224516620-9709ffe7-5435-4abb-b91d-c4a69ddf9448.png)

So to solve this I used the String.replace() function to replace the characters in Unicode with a group of characters. Then the String.fromCharCode() function is used to convert the string of characters to its equivalent in ASCII characters. Finally, the conversion result is returned to the String.replace() function.

![image](https://user-images.githubusercontent.com/45567815/224516673-b7fad5e0-5458-415c-8918-b0ceae828535.png)

In this file [File.zip](https://github.com/vagran/dxf-viewer/files/10949713/File.zip) have the DXF to test.
