### PR TITLE
[#36] Fix issues of start point edge case

### DIFF
--- a/src/math/Matrix2.js
+++ b/src/math/Matrix2.js
@@ -49,4 +49,29 @@ export class Matrix2 {
             -this.a10 / determinant, this.a00 / determinant,
         )
     }
+
+    /**
+     * Solve linear equation Ax = b using Gauss-Jordan reduction
+     * where A is `this`. If it's singular, return `undefined`
+     * @param {Vector2} b 
+     * @returns {Vector2 | undefined}
+     */
+    solve(b) {
+        if (this.a00 * this.a11 === this.a10 * this.a01) return undefined
+
+        if (Math.abs(this.a00) >= Math.abs(this.a10)) {
+            const alpha = this.a10 / this.a00
+            const beta = this.a11 - this.a01 * alpha
+            const gamma = b.y - b.x * alpha
+            const y = gamma / beta
+            const x = (b.x - this.a01 * y) / this.a00
+            return new Vector2(x, y)
+        }
+        const alpha = this.a00 / this.a10
+        const beta = this.a01 - this.a11 * alpha
+        const gamma = b.x - b.y * alpha
+        const y = gamma / beta
+        const x = (b.y - this.a11 * y) / this.a10
+        return new Vector2(x, y)
+    }
 }


### PR DESCRIPTION
Related comment: https://github.com/vagran/dxf-viewer/issues/36#issuecomment-1500921337

Fix hatch pattern calculator line refinement logic to use more robust way. 

More better idea has came. Not use even-odd parity, but use whether each edges are in paths. This method doesn't have to detect singularity that I've mentioned, and more reliable.

For each adjacent intersection pair, if that edge is inside of the polygon, then just included it. Otherwise do not include. This is more computational intensive but it'll be optimized using R-tree later, by not scanning every edges of the path(s).

![image](https://user-images.githubusercontent.com/14037015/230745482-4fb98476-3d2c-4e19-bd77-d203c2d89f74.png)

@vagran 's suggested paper was pretty brilliant, but I'm not sure how should I modify that so that it works with multiple polygons (=`this.boundaryPaths`), not just a single one. And time complexity is same so I just stick to current implementation.