### PR TITLE
Add preserveDrawingBuffer to default options

### DIFF
--- a/src/DxfViewer.js
+++ b/src/DxfViewer.js
@@ -37,7 +37,8 @@ export class DxfViewer {
                 alpha: options.canvasAlpha,
                 premultipliedAlpha: options.canvasPremultipliedAlpha,
                 antialias: options.antialias,
-                depth: false
+                depth: false,
+				preserveDrawingBuffer: options.preserveDrawingBuffer
             })
         } catch (e) {
             console.log("Failed to create renderer: " + e)
@@ -685,7 +686,9 @@ DxfViewer.DefaultOptions = {
     /** Scene generation options. */
     sceneOptions: DxfScene.DefaultOptions,
     /** Retain the simple object representing the parsed DXF - will consume a lot of additional memory */
-    retainParsedDxf: false
+    retainParsedDxf: false,
+	/** Whether to preserve the buffers until manually cleared or overwritten */
+    preserveDrawingBuffer: false
 }
 
 DxfViewer.SetupWorker = function () {

--- a/src/DxfViewer.js
+++ b/src/DxfViewer.js
@@ -38,7 +38,7 @@ export class DxfViewer {
                 premultipliedAlpha: options.canvasPremultipliedAlpha,
                 antialias: options.antialias,
                 depth: false,
-				preserveDrawingBuffer: options.preserveDrawingBuffer
+                preserveDrawingBuffer: options.preserveDrawingBuffer
             })
         } catch (e) {
             console.log("Failed to create renderer: " + e)
@@ -687,7 +687,7 @@ DxfViewer.DefaultOptions = {
     sceneOptions: DxfScene.DefaultOptions,
     /** Retain the simple object representing the parsed DXF - will consume a lot of additional memory */
     retainParsedDxf: false,
-	/** Whether to preserve the buffers until manually cleared or overwritten */
+    /** Whether to preserve the buffers until manually cleared or overwritten */
     preserveDrawingBuffer: false
 }
 


### PR DESCRIPTION
Hi there,

we would like to suggest to add `preserveDrawingBuffer` to the `DxfViewer.DefaultOptions`. It still defaults to `false` so there shouldn't be any side effects when not setting it.

The reason for this change is that we need to take screenshots of multiple layered canvas objects in our application, and for this to work, the renderer's drawing buffer needs to be preserved.

Thx 