### PR TITLE
Add missing indices when decomposing faces

### DIFF
--- a/src/DxfScene.js
+++ b/src/DxfScene.js
@@ -835,6 +835,7 @@ export class DxfScene {
                     indices.push(0, 1, 2)
                 } else {
                     indices.push(1, 2, 3)
+                    indices.push(2, 3, 0)
                 }
                 _vertices.push(v3)
             }


### PR DESCRIPTION
Hi again, 

we would like to suggest a small change in the decomposition of faces. In some dxf files we experienced minor rendering artifacts because the surfaces were not closed properly. 

**UI**
Before:
![before](https://github.com/vagran/dxf-viewer/assets/1718257/75036b61-156b-4f54-96d4-fc4a82dfcb3b)

After:
![after](https://github.com/vagran/dxf-viewer/assets/1718257/e3bedc76-c9bc-4c3f-af6d-8e06102e0158)

Thx



