### PR TITLE
Add "type: module" to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "author": "Artyom Lebedev<artyom.lebedev@gmail.com>",
     "license": "MPL-2.0",
     "repository": "https://github.com/vagran/dxf-viewer",
+    "type": "module",
     "keywords": [
         "dxf",
         "viewer",


### PR DESCRIPTION
so imported files are loaded correctly.

This should help avoid errors like the following, by telling node that the files don't use the cjs syntax for importing and exporting:

```
export {DxfFetcher} from "./DxfFetcher"
^^^^^^

SyntaxError: Unexpected token 'export'
    at compileFunction (<anonymous>)
    at Object.compileFunction (node:vm:352:18)
    at wrapSafe (node:internal/modules/cjs/loader:1032:15)
    at Module._compile (node:internal/modules/cjs/loader:1067:27)
```

See the [node.js docs](https://nodejs.org/docs/latest-v13.x/api/esm.html#esm_enabling) for more info on using esm in node libraries.