### PR TITLE
handle LWPOLYLINE with non-contiguous vertices data

### DIFF
--- a/src/parser/entities/lwpolyline.js
+++ b/src/parser/entities/lwpolyline.js
@@ -27,7 +27,8 @@ EntityParser.prototype.parseEntity = function(scanner, curr) {
             numberOfVertices = curr.value;
             break;
         case 10: // X coordinate of point
-            entity.vertices = parseLWPolylineVertices(numberOfVertices, scanner);
+            let vertices = parseLWPolylineVertices(numberOfVertices, scanner);
+            entity.vertices = entity.vertices ? entity.vertices.concat(vertices) : vertices;
             break;
         case 43:
             if(curr.value !== 0) entity.width = curr.value;


### PR DESCRIPTION
I noticed that sometimes LWPOLYLINE entities have their vertices in chunks, and the existing implementation would overwrite the array with the most recent, leading to points being missing. I made the following modification and the shapes started rendering properly.