### PR TITLE
Various MText improvements and small fixes

### DIFF
--- a/src/DxfScene.js
+++ b/src/DxfScene.js
@@ -1029,12 +1029,6 @@ export class DxfScene {
         }
 
         const style = entity.hatchStyle ?? 0
-
-        if (style != HatchStyle.ODD_PARITY && style != HatchStyle.THROUGH_ENTIRE_AREA) {
-            //XXX other styles not yet supported
-            return
-        }
-
         const boundaryLoops = this._GetHatchBoundaryLoops(entity)
         if (boundaryLoops.length == 0) {
             console.warn("HATCH entity with empty boundary loops array " +

--- a/src/DxfScene.js
+++ b/src/DxfScene.js
@@ -2121,7 +2121,8 @@ export class DxfScene {
             scene.layers.push({
                 name: layer.name,
                 displayName: layer.displayName,
-                color: layer.color
+                color: layer.color,
+                visible: layer.visible
             })
         }
 

--- a/src/DxfScene.js
+++ b/src/DxfScene.js
@@ -885,7 +885,8 @@ export class DxfScene {
             attachment: entity.attachmentPoint,
             lineSpacing: entity.lineSpacing,
             width: entity.width,
-            color, layer
+            color, layer,
+            columns: entity.columns
         })
     }
 

--- a/src/DxfScene.js
+++ b/src/DxfScene.js
@@ -119,6 +119,7 @@ export class DxfScene {
         /* 0 - CCW, 1 - CW */
         this.angDir = this.vars.get("ANGDIR") ?? 0
         this.pdSize = this.vars.get("PDSIZE") ?? 0
+        this.pdMode = this.vars.get("PDMODE") ?? 0
         this.isMetric = (this.vars.get("MEASUREMENT") ?? 1) == 1
 
         if(dxf.tables && dxf.tables.layer) {

--- a/src/DxfScene.js
+++ b/src/DxfScene.js
@@ -1985,7 +1985,7 @@ export class DxfScene {
             color = ColorCode.BY_BLOCK
         } else if (entity.colorIndex === 256) {
             color = ColorCode.BY_LAYER
-        } else if (entity.hasOwnProperty("color")) {
+        } else if (entity.color) {
             color = entity.color
         }
 

--- a/src/DxfViewer.js
+++ b/src/DxfViewer.js
@@ -448,16 +448,27 @@ export class DxfViewer {
         this._Emit(e.type, {
             domEvent: e,
             canvasCoord,
-            position: this._CanvasToSceneCoord(canvasCoord.x, canvasCoord.y)
+            position: this.CanvasToSceneCoord(canvasCoord.x, canvasCoord.y)
         })
     }
 
     /** @return {{x,y}} Scene coordinate corresponding to the specified canvas pixel coordinates. */
-    _CanvasToSceneCoord(x, y) {
+    CanvasToSceneCoord(x, y) {
+        if (x < 0 || this.canvasWidth <= x || y < 0 || this.canvasHeight <= y) return null;
+
         const v = new three.Vector3(x * 2 / this.canvasWidth - 1,
                                     -y * 2 / this.canvasHeight + 1,
                                     1).unproject(this.camera)
         return {x: v.x, y: v.y}
+    }
+
+    SceneToCanvasCoord(x, y) {
+        const v = new three.Vector3(x, y, 1).project(this.camera)
+        const cx = (v.x + 1) * this.canvasWidth / 2;
+        const cy = (-v.y + 1) * this.canvasHeight / 2;
+
+        if (cx < 0 || this.canvasWidth <= cx || cy < 0 || this.canvasHeight <= cy) return null;
+        return {x: cx, y: cy}
     }
 
     _OnResize(entry) {

--- a/src/DxfViewer.js
+++ b/src/DxfViewer.js
@@ -88,6 +88,7 @@ export class DxfViewer {
 
         this.canvas.addEventListener("pointerdown", this._OnPointerEvent.bind(this))
         this.canvas.addEventListener("pointerup", this._OnPointerEvent.bind(this))
+        this.canvas.addEventListener("pointermove", this._OnPointerEvent.bind(this))
 
         this.Render()
 
@@ -374,6 +375,7 @@ export class DxfViewer {
      *  * "resized" - viewport size changed. Details: {width, height}
      *  * "pointerdown" - Details: {domEvent, position:{x,y}}, position is in scene coordinates.
      *  * "pointerup"
+     *  * "pointermove"
      *  * "viewChanged"
      *  * "message" - Some message from the viewer. {message: string, level: string}.
      *

--- a/src/DxfViewer.js
+++ b/src/DxfViewer.js
@@ -188,7 +188,7 @@ export class DxfViewer {
         this.hasMissingChars = scene.hasMissingChars
 
         for (const layer of scene.layers) {
-            this.layers.set(layer.name, new Layer(layer.name, layer.displayName, layer.color))
+            this.layers.set(layer.name, new Layer(layer.name, layer.displayName, layer.color, layer.visible))
         }
 
         /* Load all blocks on the first pass. */
@@ -245,14 +245,15 @@ export class DxfViewer {
         this.renderer.render(this.scene, this.camera)
     }
 
-    /** @return {Iterable<{name:String, color:number}>} List of layer names. */
+    /** @return {Iterable<{name:String, displayName: String, color:number, visible: boolean}>} List of layer names. */
     GetLayers() {
         const result = []
         for (const lyr of this.layers.values()) {
             result.push({
                 name: lyr.name,
                 displayName: lyr.displayName,
-                color: this._TransformColor(lyr.color)
+                color: this._TransformColor(lyr.color),
+                visible: lyr.visible
             })
         }
         return result
@@ -264,6 +265,8 @@ export class DxfViewer {
         if (!layer) {
             return
         }
+
+        layer.visible = show
         for (const obj of layer.objects) {
             obj.visible = show
         }
@@ -490,6 +493,7 @@ export class DxfViewer {
             this.scene.add(obj)
             if (layer) {
                 layer.PushObject(obj)
+                if (!layer.visible) obj.visible = false
             }
         }
     }
@@ -943,10 +947,11 @@ class Batch {
 }
 
 class Layer {
-    constructor(name, displayName, color) {
+    constructor(name, displayName, color, visible) {
         this.name = name
         this.displayName = displayName
         this.color = color
+        this.visible = visible
         this.objects = []
     }
 

--- a/src/DxfViewer.js
+++ b/src/DxfViewer.js
@@ -126,6 +126,8 @@ export class DxfViewer {
     }
 
     SetSize(width, height) {
+        if (width <= 0 || height <= 0) return;
+
         this._EnsureRenderer()
 
         const hScale = width / this.canvasWidth

--- a/src/DxfViewer.js
+++ b/src/DxfViewer.js
@@ -84,7 +84,6 @@ export class DxfViewer {
             this.resizeObserver = new ResizeObserver(entries => this._OnResize(entries[0]))
             this.resizeObserver.observe(domContainer)
         }
-        domContainer.appendChild(this.canvas)
 
         this.canvas.addEventListener("pointerdown", this._OnPointerEvent.bind(this))
         this.canvas.addEventListener("pointerup", this._OnPointerEvent.bind(this))
@@ -221,6 +220,9 @@ export class DxfViewer {
         }
 
         this._Emit("loaded")
+        if (!this.canvas.parentNode) {
+            this.domContainer.appendChild(this.canvas)
+        }
 
         if (scene.bounds) {
             this.FitView(scene.bounds.minX - scene.origin.x, scene.bounds.maxX - scene.origin.x,
@@ -312,6 +314,8 @@ export class DxfViewer {
         this.simpleColorMaterial = null
         this.renderer.dispose()
         this.renderer = null
+
+        this.canvas.remove();
     }
 
     SetView(center, width) {

--- a/src/HatchCalculator.js
+++ b/src/HatchCalculator.js
@@ -302,8 +302,8 @@ class ClipCalculator {
 }
 
 export class HatchCalculator {
-    boundaryLoops
-    style
+    boundaryLoops;
+    style;
 
     /**
      * Arrays of `Path` to use as boundary, and each `Path` is array of `Point`.

--- a/src/MTextFormatParser.js
+++ b/src/MTextFormatParser.js
@@ -169,7 +169,7 @@ export class MTextFormatParser {
             const numStart = cursor
             SkipWhile((c) => isNumberChar(c))
 
-            const number = parseFloat(text.substring(numStart, text.length));
+            const number = parseFloat(text.substring(numStart, cursor));
             if (isNaN(number)) return defaultValue
             return number
         }

--- a/src/MTextFormatParser.js
+++ b/src/MTextFormatParser.js
@@ -23,7 +23,8 @@ const EntityType = Object.freeze({
     /** "alignment" property is either "r", "c", "l", "j", "d" for right, center, left, justify
      * (seems to be the same as left), distribute (justify) alignment.
      */
-    PARAGRAPH_ALIGNMENT: 4
+    PARAGRAPH_ALIGNMENT: 4,
+    TAB: 5,
 
     /* Many others are not yet implemented. */
 })
@@ -65,6 +66,13 @@ export class MTextFormatParser {
                 content: text.slice(textStart, curPos)
             })
             textStart = curPos
+        }
+
+        function EmitTab() {
+            curEntities.push({
+                type: EntityType.TAB,
+                content: ""
+            })
         }
 
         function EmitEntity(type) {
@@ -160,7 +168,8 @@ export class MTextFormatParser {
 
             case State.CARET:
                 switch (c) {
-                    case "I": // XXX Handle Tab
+                    case "I": // TODO: Parse custom tab stops
+                        EmitTab();
                         break
                     case "J":
                         EmitEntity(EntityType.PARAGRAPH)

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -47,7 +47,7 @@ export type LayerInfo = {
 }
 
 export type EventName = "loaded" | "cleared" | "destroyed" | "resized" | "pointerdown" |
-    "pointerup" | "viewChanged" | "message"
+    "pointerup" | "pointermove" | "viewChanged" | "message"
 
 export declare class DxfViewer {
     constructor(domContainer: HTMLElement, options: DxfViewerOptions | null)

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -69,6 +69,8 @@ export declare class DxfViewer {
     ShowLayer(name: string, show: boolean): void
     Subscribe(eventName: EventName, eventHandler: (event: any) => void): void
     Unsubscribe(eventName: EventName, eventHandler: (event: any) => void): void
+    CanvasToSceneCoord(canvasX: number, canvasY: number): {x: number, y: number}
+    SceneToCanvasCoord(sceneX: number, sceneY: number): {x: number, y: number} | null
 }
 
 export declare namespace DxfViewer {

--- a/src/parser/entities/hatch.js
+++ b/src/parser/entities/hatch.js
@@ -218,7 +218,6 @@ function ParseBoundaryLoop(curr, scanner) {
             //XXX ignore some groups for now, mostly spline
             case 95:
             case 96:
-            case 40:
             case 42:
             case 97:
                 break;

--- a/src/parser/entities/mtext.js
+++ b/src/parser/entities/mtext.js
@@ -42,7 +42,7 @@ EntityParser.prototype.parseEntity = function(scanner, curr) {
             entity.drawingDirection = curr.value;
             break;
         case 101:
-            helpers.skipEmbeddedObject(scanner);
+            entity.columns = parseMTextColumns(scanner, curr, entity);
             break;
         default:
             helpers.checkCommonEntityProperties(entity, curr, scanner);
@@ -50,5 +50,77 @@ EntityParser.prototype.parseEntity = function(scanner, curr) {
         }
         curr = scanner.next();
     }
+    delete entity.columns;
     return entity;
 };
+
+const ColumnType = Object.freeze({
+    None: 0,
+    Dynamic: 1,
+    Static: 2,
+});
+
+// Based on https://github.com/mozman/ezdxf/blob/9241936736e6045be4b89dc24a9c871a80469148/src/ezdxf/entities/mtext.py#L439
+function parseMTextColumns(scanner, curr, parent) {
+    const columnEntity = { type: curr.value, heights: [] };
+    do {
+        curr = scanner.next();
+
+        switch (curr.code) {
+            case 10:
+                if (!parent.direction) {
+                    // parent.direction = helpers.parsePoint(scanner);
+                    // delete parent.rotation;
+                }
+                break;
+            case 11:
+                if (!parent.position) {
+                    // parent.position = helpers.parsePoint(scanner);
+                }
+                break;
+            case 40:
+                parent.width = curr.value;
+                break;
+            case 41:
+                columnEntity.defined_height = curr.value;
+                break;
+            case 42:
+                columnEntity.total_width = curr.value;
+                break;
+            case 43:
+                columnEntity.total_height = curr.value;
+                break;
+            case 44:
+                columnEntity.column_width = curr.value;
+                break;
+            case 45:
+                columnEntity.gutter_width = curr.value;
+                break;
+            case 71:
+                columnEntity.column_type = curr.value;
+                break;
+            case 72:
+                columnEntity.count = curr.value;
+                break;
+            case 73:
+                columnEntity.auto_height = curr.value;
+                break;
+            case 74:
+                columnEntity.reversed_column_flow = curr.value;
+                break;
+            case 46:
+                columnEntity.heights.push(curr.value);
+        }
+    } while (curr.code !== 0);
+    scanner.rewind();
+
+    if (columnEntity.count === 0) {
+        if (columnEntity.heights.length > 0) {
+            columnEntity.count = columnEntity.heights.length;
+        } else if (columnEntity.total_width > 0) {
+            const gw = columnEntity.gutter_width || 0;
+            columnEntity.count = (columnEntity.total_width + gw) / (columnEntity.column_width + gw);
+        }
+    }
+    return columnEntity;
+}

--- a/src/parser/entities/mtext.js
+++ b/src/parser/entities/mtext.js
@@ -50,7 +50,6 @@ EntityParser.prototype.parseEntity = function(scanner, curr) {
         }
         curr = scanner.next();
     }
-    delete entity.columns;
     return entity;
 };
 
@@ -69,13 +68,13 @@ function parseMTextColumns(scanner, curr, parent) {
         switch (curr.code) {
             case 10:
                 if (!parent.direction) {
-                    // parent.direction = helpers.parsePoint(scanner);
-                    // delete parent.rotation;
+                    parent.direction = helpers.parsePoint(scanner);
+                    delete parent.rotation;
                 }
                 break;
             case 11:
                 if (!parent.position) {
-                    // parent.position = helpers.parsePoint(scanner);
+                    parent.position = helpers.parsePoint(scanner);
                 }
                 break;
             case 40:


### PR DESCRIPTION
Almost forgot about this, I hope the commits are somewhat self-explanatory. Let me know if anything should be changed, although I never want to work with JS again. Would be great to see the TS port and new parser completed.

I used https://github.com/mozman/ezdxf/blob/master/docs/source/dxfinternals/entities/mtext.rst and https://github.com/skymakerolof/dxf/blob/develop/src/handlers/entity/mtext.js as references to figure stuff out and of course just playing around in AutoCAD.

I've attached a file which can be used to compare the before and after, mostly regarding MText columns.
AutoCAD reference:
![image](https://github.com/vagran/dxf-viewer/assets/36999320/c17b3ab1-4bb9-4665-a883-dad3a878a670)
[columns-all.dxf.txt](https://github.com/vagran/dxf-viewer/files/14763189/columns-all.dxf.txt)
