### PR TITLE
Get vertices from hatch boundary loop when style is THROUGH_ENTIRE_AREA

### DIFF
--- a/src/DxfScene.js
+++ b/src/DxfScene.js
@@ -1082,7 +1082,7 @@ export class DxfScene {
 
         if (style == HatchStyle.THROUGH_ENTIRE_AREA) {
             /* Leave only external loop. */
-            filteredBoundaryLoops = [boundaryLoops[0]]
+            filteredBoundaryLoops = [boundaryLoops[0].vertices]
 
         } else if (style == HatchStyle.OUTERMOST) {
             /* Leave external and outermost loop. */


### PR DESCRIPTION
When decomposing hatch entities, there is a bug where the entire boundary loop object is added to the filtered boundary loops instead of just its vertices.  This only occurred when the hatch style was THROUGH_ENTIRE_AREA.  This commit corrects this bug.

I added a simple dxf file (has extra .txt extension because github wouldn't allow uploading a .dxf extension) which has a single hatch entity with THROUGH_ENTIRE_AREA style.  When tested on https://vagran.github.io/dxf-viewer-example/ this file raises the error `Error occurred: TypeError: e is not iterable` because the code was expecting the iterable vertices array, but instead got the whole boundary loop object.  With my code changes it loads correctly.

[single_hatch.dxf.txt](https://github.com/user-attachments/files/18601819/single_hatch.dxf.txt)
