### PR TITLE
Fix: Change type definitions to make DxfViewerOptions properties optional

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -15,21 +15,21 @@ export type DxfSceneOptions = {
 
 /** See DxfViewer.DefaultOptions for default values and documentation. */
 export type DxfViewerOptions = {
-    canvasWidth: number,
-    canvasHeight: number,
-    autoResize: boolean,
-    clearColor: THREE.Color,
-    clearAlpha: number,
-    canvasAlpha: boolean,
-    canvasPremultipliedAlpha: boolean,
-    antialias: boolean,
-    colorCorrection: boolean,
-    blackWhiteInversion: boolean,
-    pointSize: number,
-    sceneOptions: DxfSceneOptions,
-    retainParsedDxf: boolean,
-    preserveDrawingBuffer: boolean,
-    fileEncoding: string
+    canvasWidth?: number,
+    canvasHeight?: number,
+    autoResize?: boolean,
+    clearColor?: THREE.Color,
+    clearAlpha?: number,
+    canvasAlpha?: boolean,
+    canvasPremultipliedAlpha?: boolean,
+    antialias?: boolean,
+    colorCorrection?: boolean,
+    blackWhiteInversion?: boolean,
+    pointSize?: number,
+    sceneOptions?: DxfSceneOptions,
+    retainParsedDxf?: boolean,
+    preserveDrawingBuffer?: boolean,
+    fileEncoding?: string
 }
 
 export type DxfViewerLoadParams = {


### PR DESCRIPTION
# Make DxfViewerOptions properties optional

This PR updates the typing to allow for partial configuration of the DxfViewer.

## Impact
- Improves TypeScript type definitions to better match the actual behavior of the DxfViewer
- More flexible API that allows partial configuration
- Backwards compatible change as existing code passing full options will continue to work

## Testing
- No runtime changes, TypeScript type definition update only