### PR TITLE
fix: always return when event type is PROGRESS

### DIFF
--- a/src/DxfWorker.js
+++ b/src/DxfWorker.js
@@ -107,8 +107,10 @@ export class DxfWorker {
             return
         }
         const data = msg.data
-        if (msg.type === DxfWorker.WorkerMsg.PROGRESS && req.progressCbk) {
-            req.progressCbk(data.phase, data.size, data.totalSize)
+        if (msg.type === DxfWorker.WorkerMsg.PROGRESS) {
+            if (req.progressCb) {
+                req.progressCbk(data.phase, data.size, data.totalSize)
+            }
             return
         }
         this.requests.delete(seq)


### PR DESCRIPTION
close #131

I am not sure if PROGRESS event should always return but deleting the request causes the Unmatched message sequence error to happen.
