### PR TITLE
Marks some Load Parameter as optional

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -34,10 +34,10 @@ export type DxfViewerOptions = {
 
 export type DxfViewerLoadParams = {
     url: string,
-    fonts: string[] | null,
-    progressCbk: ((phase: "font" | "fetch" | "parse" | "prepare",
+    fonts?: string[] | null,
+    progressCbk?: ((phase: "font" | "fetch" | "parse" | "prepare",
                    processedSize: number, totalSize: number) => void) | null,
-    workerFactory: (() => Worker) | null
+    workerFactory?: (() => Worker) | null
 }
 
 export type LayerInfo = {


### PR DESCRIPTION
Update the type declaration for the Load parameters "font", "progressCbk" and "workerFactory" to mark them as optional.
These parameters are already declared as optional in the JSDoc of the Load function who will assign them to "null" if they are not set.
