### PR TITLE
feat: add the webgl renderer to dxf viewer options

### DIFF
--- a/src/DxfViewer.js
+++ b/src/DxfViewer.js
@@ -35,18 +35,23 @@ export class DxfViewer {
 
         this.scene = new three.Scene()
 
-        try {
-            this.renderer = new three.WebGLRenderer({
-                alpha: options.canvasAlpha,
-                premultipliedAlpha: options.canvasPremultipliedAlpha,
-                antialias: options.antialias,
-                depth: false,
-                preserveDrawingBuffer: options.preserveDrawingBuffer
-            })
-        } catch (e) {
-            console.log("Failed to create renderer: " + e)
-            this.renderer = null
-            return
+       this.ownsRenderer = !options.renderer
+       this.renderer = options.renderer
+
+       if(!this.renderer) {
+           try {
+               this.renderer = new three.WebGLRenderer({
+                   alpha: options.canvasAlpha,
+                   premultipliedAlpha: options.canvasPremultipliedAlpha,
+                   antialias: options.antialias,
+                   depth: false,
+                   preserveDrawingBuffer: options.preserveDrawingBuffer
+                })
+            } catch (e) {
+                console.log("Failed to create renderer: " + e)
+                this.renderer = null
+                return
+            }
         }
         const renderer = this.renderer
         /* Prevent bounding spheres calculations which fails due to non-conventional geometry
@@ -317,7 +322,9 @@ export class DxfViewer {
         }
         this.simplePointMaterial = null
         this.simpleColorMaterial = null
-        this.renderer.dispose()
+        if(this.ownsRenderer) {
+            this.renderer.dispose()
+        }
         this.renderer = null
     }
 
@@ -724,7 +731,12 @@ DxfViewer.DefaultOptions = {
      * be a subject for future changes. The specified value should be suitable for passing as
      * `TextDecoder` constructor `label` parameter.
      */
-    fileEncoding: "utf-8"
+    fileEncoding: "utf-8",
+    /**
+     * @type {three.WebGLRenderer | undefined | null} 
+     * The Webgl renderer to use. If not specified, a new renderer will be created.
+     */
+    renderer: undefined
 }
 
 DxfViewer.SetupWorker = function () {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -30,6 +30,7 @@ export type DxfViewerOptions = {
     retainParsedDxf?: boolean,
     preserveDrawingBuffer?: boolean,
     fileEncoding?: string
+    renderer?: THREE.WebGLRenderer | null,
 }
 
 export type DxfViewerLoadParams = {


### PR DESCRIPTION
## What
Add an option to pass a webgl renderer to the viewer.

## Why

For the general case, it can allow people to directly tweak the renderer without the need of DXF viewer to directly expose is as options.

My use case is quite more specific: I want to be able to reuse a same webgl renderer across many viewers. 

I work on an app that may display DXFs simultaneously. Recently, I was reported the following issue: when users were creating views with many DXF, some DXF or other non-DXF stuff started to disappear. The reason is that a web browser only allows a limited amount of webgl context to exist simultaneously. On a page with many DXF viewer, above some browser dependent threshold, the DXF viewer will stop working as they will lose their WebGL context. On Firefox, this threshold is quite high, but on chrome, it seems to be 16.

With this change, I can create multiple viewers, all using a same renderer, which mean the same canvas and the same webgl context. This render canvas will be offscreen.  After each rendering, I copy the content of this canvas in different canvas visible in the document. Those visible canvases do not require a webgl context, I can have as many as I want in my page.

I know this is quite a specific use case, but probably that allowing the user to create the WebGL renderer themselves could be useful for other specific use cases.
