### PR TITLE
feat: add zoom parameter to SetView method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dxf-viewer",
-    "version": "1.0.43",
+    "version": "1.0.44",
     "description": "JavaScript DXF file viewer",
     "main": "src/index.js",
     "author": "Artyom Lebedev<artyom.lebedev@gmail.com>",

--- a/src/DxfViewer.js
+++ b/src/DxfViewer.js
@@ -321,7 +321,7 @@ export class DxfViewer {
         this.renderer = null
     }
 
-    SetView(center, width) {
+    SetView(center, width, zoom = 1) {
         const aspect = this.canvasWidth / this.canvasHeight
         const height = width / aspect
         const cam = this.camera
@@ -329,7 +329,7 @@ export class DxfViewer {
         cam.right = width / 2
         cam.top = height / 2
         cam.bottom = -height / 2
-        cam.zoom = 1
+        cam.zoom = zoom
         cam.position.set(center.x, center.y, 1)
         cam.rotation.set(0, 0, 0)
         cam.updateMatrix()

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -65,7 +65,7 @@ export declare class DxfViewer {
     Load(params: DxfViewerLoadParams): Promise<void>
     Render(): void
     SetSize(width: number, height: number): void
-    SetView(center: THREE.Vector3, width: number): void
+    SetView(center: THREE.Vector3, width: number, zoom: number): void
     ShowLayer(name: string, show: boolean): void
     Subscribe(eventName: EventName, eventHandler: (event: any) => void): void
     Unsubscribe(eventName: EventName, eventHandler: (event: any) => void): void


### PR DESCRIPTION
The SetView method in DxfViewer now accepts an optional zoom parameter, allowing callers to specify the camera zoom level. Type definitions have been updated accordingly. Version bumped to 1.0.44.