### PR TITLE
fix: make zoom parameter in SetView optional in typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dxf-viewer",
-    "version": "1.0.44",
+    "version": "1.0.45",
     "description": "JavaScript DXF file viewer",
     "main": "src/index.js",
     "author": "Artyom Lebedev<artyom.lebedev@gmail.com>",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -65,7 +65,7 @@ export declare class DxfViewer {
     Load(params: DxfViewerLoadParams): Promise<void>
     Render(): void
     SetSize(width: number, height: number): void
-    SetView(center: THREE.Vector3, width: number, zoom: number): void
+    SetView(center: THREE.Vector3, width: number, zoom?: number): void
     ShowLayer(name: string, show: boolean): void
     Subscribe(eventName: EventName, eventHandler: (event: any) => void): void
     Unsubscribe(eventName: EventName, eventHandler: (event: any) => void): void


### PR DESCRIPTION
Updated the TypeScript definition for DxfViewer.SetView to make the zoom parameter optional. Bumped package version to 1.0.45.