### PR TITLE
Adding CDN example and adding support for WOFF text format

### DIFF
--- a/html_example/test-dxf-text.html
+++ b/html_example/test-dxf-text.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>DXF Text Rendering Test</title>
+    <script type="importmap">
+    {
+        "imports": {
+            "three": "https://cdn.jsdelivr.net/npm/three@0.161.0/+esm",
+            "three/": "https://cdn.jsdelivr.net/npm/three@0.161.0/",
+            "loglevel": "https://cdn.jsdelivr.net/npm/loglevel@1.9.1/+esm",
+            "opentype.js": "https://cdn.jsdelivr.net/npm/opentype.js@1.3.4/+esm",
+            "earcut": "https://cdn.jsdelivr.net/npm/earcut@3.0.0/+esm"
+        }
+    }
+    </script>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+            background: #f5f5f5;
+        }
+        h1 {
+            color: #333;
+        }
+        #dxf-viewer-container {
+            margin-top: 30px;
+            border: 2px solid #ddd;
+            border-radius: 8px;
+            background: #ffffff;
+            position: relative;
+            width: 100%;
+            height: 600px;
+        }
+        #dxf-error-message {
+            margin-top: 20px;
+            padding: 15px;
+            background: #f8d7da;
+            border-radius: 4px;
+            color: #721c24;
+            display: none;
+        }
+    </style>
+</head>
+<body>
+    <h1>DXF Text Rendering Test</h1>
+    <p>Testing text rendering in DXF viewer with various fonts.</p>
+
+    <button id="download-dxf-btn" style="padding: 10px 20px; font-size: 16px; cursor: pointer; margin-bottom: 20px;">Download DXF File</button>
+
+    <div id="dxf-viewer-container"></div>
+
+    <div id="dxf-error-message">
+        <strong>Error:</strong> <span id="dxf-error-text"></span>
+    </div>
+
+    <script type="module">
+        import * as THREE from "three";
+        import { DxfViewer } from "../src/index.js";
+        import Drawing from "https://cdn.jsdelivr.net/npm/dxf-writer@1.18.4/+esm";
+
+        function showError(message) {
+            document.getElementById("dxf-error-text").textContent = message;
+            document.getElementById("dxf-error-message").style.display = "block";
+        }
+
+        async function createAndRenderDXF() {
+            try {
+                // Create DXF drawing
+                const drawing = new Drawing();
+                drawing.setUnits("Inches");
+
+                // Add line types
+                drawing.addLineType("DASHED", "---- ", [0.5, -0.5]);
+                drawing.addLineType("DOTTED", ". ", [0.1, -0.1]);
+
+                // Create layers
+                drawing.addLayer("BORDER", 1, "CONTINUOUS");
+                drawing.addLayer("DIAGONAL", 5, "DASHED");
+                drawing.addLayer("CUSTOM", 4, "CONTINUOUS");
+                drawing.addLayer("CIRCLES", 3, "CONTINUOUS");
+                drawing.addLayer("TEXT", 8, "CONTINUOUS");
+
+                // Draw border
+                drawing.setActiveLayer("BORDER");
+                drawing.drawLine(0, 0, 10, 0);
+                drawing.drawLine(10, 0, 10, 8);
+                drawing.drawLine(10, 8, 0, 8);
+                drawing.drawLine(0, 8, 0, 0);
+
+                // Draw diagonal lines
+                drawing.setActiveLayer("DIAGONAL");
+                drawing.drawLine(0, 0, 10, 8);
+                drawing.drawLine(10, 0, 0, 8);
+
+                // Draw rectangle
+                drawing.setActiveLayer("CUSTOM");
+                drawing.drawLine(3, 2, 7, 2);
+                drawing.drawLine(7, 2, 7, 6);
+                drawing.drawLine(7, 6, 3, 6);
+                drawing.drawLine(3, 6, 3, 2);
+
+                // Draw X inside rectangle
+                drawing.drawLine(3, 2, 7, 6);
+                drawing.drawLine(7, 2, 3, 6);
+
+                // Draw circle
+                drawing.setActiveLayer("CIRCLES");
+                drawing.drawCircle(5, 4, 1);
+
+                // Draw text - make it HUGE and change layer color to bright white
+                drawing.addLayer("TEXT", 7, "CONTINUOUS");  // 7 = white color
+                drawing.setActiveLayer("TEXT");
+
+                // Test full alphabet - uppercase
+                drawing.drawText(0.5, 7, 0.3, 0, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+
+                // Test full alphabet - lowercase
+                drawing.drawText(0.5, 6.5, 0.3, 0, "abcdefghijklmnopqrstuvwxyz");
+
+                // Test numbers and special characters with holes
+                drawing.drawText(0.5, 6, 0.3, 0, "0123456789 @&#%");
+
+                // Test specific hole characters
+                drawing.drawText(1, 4, 0.8, 0, "ADOPQR");
+
+                // Get DXF string
+                const dxfString = drawing.toDxfString();
+
+                // Create viewer
+                const container = document.getElementById("dxf-viewer-container");
+                if (!container) {
+                    throw new Error("Viewer container element not found");
+                }
+
+                const viewer = new DxfViewer(container, {
+                    autoResize: true,
+                    clearColor: new THREE.Color("#000"),  // Black background for better contrast
+                    colorCorrection: false
+                });
+
+                // Create blob URL for DXF
+                const blob = new Blob([dxfString], { type: "application/dxf" });
+                const url = URL.createObjectURL(blob);
+
+                // Use WOFF font from cdnfonts (which our modified viewer now supports!)
+                const fontUrls = [
+                    "https://fonts.cdnfonts.com/s/18153/FivoSans-Regular.woff"
+                ];
+
+                // Load DXF
+                await viewer.Load({
+                    url: url,
+                    fonts: fontUrls
+                });
+
+                // Setup download button
+                document.getElementById("download-dxf-btn").addEventListener("click", () => {
+                    const blob = new Blob([dxfString], { type: "application/dxf" });
+                    const downloadUrl = URL.createObjectURL(blob);
+                    const link = document.createElement("a");
+                    link.href = downloadUrl;
+                    link.download = "alphabet-test.dxf";
+                    link.click();
+                    URL.revokeObjectURL(downloadUrl);
+                });
+
+                URL.revokeObjectURL(url);
+
+            } catch (err) {
+                console.error("Failed to render DXF:", err);
+                showError(err.message);
+            }
+        }
+
+        // Start when page loads
+        window.addEventListener('load', () => {
+            setTimeout(createAndRenderDXF, 100);
+        });
+    </script>
+</body>
+</html>

--- a/src/DxfWorker.js
+++ b/src/DxfWorker.js
@@ -173,7 +173,24 @@ export class DxfWorker {
                 if (progressCbk) {
                     progressCbk("prepare", 0, null)
                 }
-                return opentype.parse(data)
+
+                // Check if this is a WOFF file and convert to TTF if needed
+                const uint8View = new Uint8Array(data)
+                const signature = String.fromCharCode(...uint8View.slice(0, 4))
+
+                let font
+                if (signature === "wOFF" || signature === "wOF2") {
+                    // WOFF font detected - convert to TTF format
+                    const woffFont = opentype.parse(data)
+                    const ttfBuffer = woffFont.toArrayBuffer()
+                    font = opentype.parse(ttfBuffer)
+                    // Mark this font as converted from WOFF for different hole detection handling
+                    font._isConvertedFromWoff = true
+                } else {
+                    font = opentype.parse(data)
+                }
+
+                return font
             }
         }
 

--- a/src/TextRenderer.js
+++ b/src/TextRenderer.js
@@ -258,17 +258,22 @@ class CharShape {
         this.advance = glyph.advance
         this.bounds = glyph.bounds
         if (glyph.path) {
-            const shapes = glyph.path.toShapes(false)
+            // Only use automatic hole detection for WOFF-converted fonts
+            // Native TTF fonts handle holes correctly with toShapes(false)
+            const useHoleDetection = font.data && font.data._isConvertedFromWoff
+            const shapes = glyph.path.toShapes(useHoleDetection)
             this.vertices = []
             this.indices = []
             for (const shape of shapes) {
                 const shapePoints = shape.extractPoints(options.curveSubdivision)
-                /* Ensure proper vertices winding. */
-                if (!ShapeUtils.isClockWise(shapePoints.shape)) {
-                    shapePoints.shape = shapePoints.shape.reverse()
-                    for (const hole of shapePoints.holes) {
-                        if (ShapeUtils.isClockWise(hole)) {
-                            shapePoints.holes[h] = hole.reverse()
+                /* Ensure proper vertices winding when not using automatic hole detection. */
+                if (!useHoleDetection) {
+                    if (!ShapeUtils.isClockWise(shapePoints.shape)) {
+                        shapePoints.shape = shapePoints.shape.reverse()
+                        for (let h = 0; h < shapePoints.holes.length; h++) {
+                            if (ShapeUtils.isClockWise(shapePoints.holes[h])) {
+                                shapePoints.holes[h] = shapePoints.holes[h].reverse()
+                            }
                         }
                     }
                 }
@@ -368,9 +373,24 @@ class Font {
                 break
             }
         }
+
+        // Calculate bounds from glyph if not provided (some WOFF fonts don't have bounds)
+        let xMin = glyph.xMin
+        let xMax = glyph.xMax
+        let yMin = glyph.yMin
+        let yMax = glyph.yMax
+
+        if (xMin === undefined || xMax === undefined || yMin === undefined || yMax === undefined) {
+            const bounds = glyph.getBoundingBox()
+            xMin = bounds.x1
+            xMax = bounds.x2
+            yMin = bounds.y1
+            yMax = bounds.y2
+        }
+
         return {advance: glyph.advanceWidth * scale, path,
-                bounds: {xMin: glyph.xMin * scale, xMax: glyph.xMax * scale,
-                         yMin: glyph.yMin * scale, yMax: glyph.yMax * scale}}
+                bounds: {xMin: xMin * scale, xMax: xMax * scale,
+                         yMin: yMin * scale, yMax: yMax * scale}}
     }
 
     /**


### PR DESCRIPTION
This update is showing how to use dxf-viewer (and dxf-writer for dynamic dxf generation) in HTML script tags with a CDN import. TTF fonts are not widely available in CDN, so WOFF support was also added (as this is the most common format).

Note that the HTML imports in the example will need slightly altered to work outside the node environment once the source file updates are reflected in the CDN import link.